### PR TITLE
Add custom values input to Lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ commands
 
 ## Environment variables
 * `CHART_LOCATION`: chart folder; required field for `helm lint` and `helm template` executions
-* `CHART_VALUES`: custom values file for specific kubernetes environment; required field for `helm template` execution
+* `CHART_VALUES`: custom values file for specific kubernetes environment; required field for `helm template` execution; optional field for `helm lint`
 
 ## Sample
 [helm-check-action-sample](https://github.com/igabaydulin/helm-check-action-sample) is a sample which uses this action

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,11 +33,11 @@ function helmLint {
   fi
   printStepExecutionDelimeter
   if [ -z "$CHART_VALUES" ];then
-    echo "Using stock values.yaml if exists\n"
+    echo -e "Using stock values.yaml if exists\n"
     echo "helm lint $CHART_LOCATION"
     helm lint "$CHART_LOCATION"
   else
-    echo "Custom values detected..."
+    echo -e "Custom values detected...\n"
     echo "helm lint $CHART_LOCATION --values $CHART_VALUES"
     helm lint "$CHART_LOCATION" --values "$CHART_VALUES"
   fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -31,9 +31,16 @@ function helmLint {
     echo "Skipped due to condition: \$CHART_LOCATION is not provided"
     return -1
   fi
-  echo "helm lint $CHART_LOCATION"
   printStepExecutionDelimeter
-  helm lint "$CHART_LOCATION"
+  if [ -z "$CHART_VALUES" ];then
+    echo "Using stock values.yaml if exists\n"
+    echo "helm lint $CHART_LOCATION"
+    helm lint "$CHART_LOCATION"
+  else
+    echo "Custom values detected: \$CHART_VALUES provided"
+    echo "helm lint $CHART_LOCATION -f $CHART_VALUES"
+    helm lint "$CHART_LOCATION" -f "$CHART_VALUES"
+  fi
   HELM_LINT_EXIT_CODE=$?
   printStepExecutionDelimeter
   if [ $HELM_LINT_EXIT_CODE -eq 0 ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -37,9 +37,9 @@ function helmLint {
     echo "helm lint $CHART_LOCATION"
     helm lint "$CHART_LOCATION"
   else
-    echo "Custom values detected: \$CHART_VALUES provided"
-    echo "helm lint $CHART_LOCATION -f $CHART_VALUES"
-    helm lint "$CHART_LOCATION" -f "$CHART_VALUES"
+    echo "Custom values detected..."
+    echo "helm lint $CHART_LOCATION --values $CHART_VALUES"
+    helm lint "$CHART_LOCATION" --values "$CHART_VALUES"
   fi
   HELM_LINT_EXIT_CODE=$?
   printStepExecutionDelimeter


### PR DESCRIPTION
* Adds extra output for `helm lint` usage to determine if custom values provided.
* Adds logic to check if the user supply the input for custom values file
* If supplied, attempts to use the values file as input to `helm lint --values`
* Otherwise, it reverts back to stock usage with `values.yaml` if found. 